### PR TITLE
Port to NoFlo Process API

### DIFF
--- a/components/Add.coffee
+++ b/components/Add.coffee
@@ -18,13 +18,16 @@ exports.getComponent = ->
 
   c.process (input, output) ->
     return unless input.has 'host', 'in'
-    [host, data] = input.getData 'host', 'in'
-    api = ipfs host
+    [host, data] = input.get 'host', 'in'
+    return unless data.type is 'data'
 
-    if typeof data is 'string'
-      data = new Buffer data
+    api = ipfs host.data
 
-    api.add data, (err, res) ->
+    content = data.data
+    if typeof content is 'string'
+      content = new Buffer content
+
+    api.add content, (err, res) ->
       return output.sendDone err if err
       unless res?.length
         return output.sendDone new Error "No results for IPFS add"

--- a/components/Add.coffee
+++ b/components/Add.coffee
@@ -32,4 +32,4 @@ exports.getComponent = ->
       unless res?.length
         return output.sendDone new Error "No results for IPFS add"
       output.sendDone
-        hash: res[0].hash
+        hash: res[0].Hash

--- a/components/PinAdd.coffee
+++ b/components/PinAdd.coffee
@@ -10,23 +10,21 @@ exports.getComponent = ->
   c.inPorts.add 'host',
     datatype: 'string'
     default: '/ip4/127.0.0.1/tcp/5001'
+    control: true
   c.outPorts.add 'hash',
     datatype: 'string'
   c.outPorts.add 'error',
     datatype: 'object'
 
-  noflo.helpers.WirePattern c,
-    in: 'hash'
-    out: 'hash'
-    params: ['host']
-    async: true
-    forwardGroups: true
-  , (hash, groups, out, callback) ->
-    api = ipfs c.params?.host
-    api.pin.add hash, (err, res) ->
-      return callback err if err
-      unless res?.Pinned?.length
-        return callback new Error "No results for IPFS pin add"
-      out.send res.Pinned[0]
-      do callback
+  c.process (input, output) ->
+    return unless input.has 'host', 'hash'
+    [host, data] = input.get 'host', 'hash'
+    return unless data.type is 'data'
 
+    api = ipfs host.data
+    api.pin.add data.data, (err, res) ->
+      return output.sendDone err if err
+      unless res?.Pinned?.length
+        return output.sendDone new Error "No results for IPFS pin add"
+      output.sendDone
+        hash: res.Pinned[0]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "bugs": {
     "url": "https://github.com/noflo/noflo-ipfs/issues"
   },
-  "keywords": ["noflo"],
+  "keywords": [
+    "noflo"
+  ],
   "homepage": "https://github.com/noflo/noflo-ipfs#readme",
   "devDependencies": {
     "coffee-script": "^1.10.0",
@@ -26,11 +28,11 @@
     "ipfsd-ctl": "^0.8.3",
     "mocha": "^2.4.5",
     "noflo-core": "^0.1.14",
-    "noflo-nodejs": "^0.5.2"
+    "noflo-nodejs": "^0.7.0"
   },
   "dependencies": {
     "ipfs-api": "^2.13.2",
-    "noflo": "^0.6.1"
+    "noflo": "^0.7.0"
   },
   "noflo": {
     "components": {


### PR DESCRIPTION
The Process API is the new primary NoFlo component API, replacing WirePattern. See noflo/noflo#392 for more information.

See also noflo/noflo#410